### PR TITLE
Add telegram bot for stock trend suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-This telegram bot is designed to receive fresh information and recommendations on which securities are worth buying
+Trading Bot
+==========
+
+This Telegram bot collects stock data, performs simple trend analysis, and provides buy or sell suggestions. The logic relies on moving-average comparison to guess potential market direction. **Use at your own risk. This is not professional financial advice.**
+
+Setup
+-----
+1. Install dependencies:
+   ```bash
+   pip install python-telegram-bot yfinance
+   ```
+2. Set your Telegram bot token in the environment:
+   ```bash
+   export TELEGRAM_TOKEN="<your token here>"
+   ```
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,68 @@
+import os
+import logging
+import yfinance as yf
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+logging.basicConfig(level=logging.INFO)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a welcome message."""
+    await update.message.reply_text(
+        "Welcome to the trading bot. Use /recommend <TICKER> to get a suggestion."
+    )
+
+
+def analyze_ticker(ticker: str) -> str:
+    """Fetch data for *ticker* and return a recommendation."""
+    data = yf.download(ticker, period="6mo", progress=False)
+    if data.empty:
+        return "No data available for %s" % ticker
+
+    data["ma_short"] = data["Close"].rolling(window=5).mean()
+    data["ma_long"] = data["Close"].rolling(window=20).mean()
+    latest = data.iloc[-1]
+
+    message = [
+        f"{ticker} close: {latest['Close']:.2f}",
+        f"Short MA: {latest['ma_short']:.2f}",
+        f"Long MA: {latest['ma_long']:.2f}",
+    ]
+
+    if latest["ma_short"] > latest["ma_long"]:
+        message.append("Potential uptrend. Consider buying.")
+    elif latest["ma_short"] < latest["ma_long"]:
+        message.append("Potential downtrend. Consider selling.")
+    else:
+        message.append("No clear signal.")
+
+    return "\n".join(message)
+
+
+async def recommend(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the /recommend command."""
+    if not context.args:
+        await update.message.reply_text("Usage: /recommend <TICKER>")
+        return
+
+    ticker = context.args[0].upper()
+    await update.message.reply_text("Fetching data...")
+    message = analyze_ticker(ticker)
+    await update.message.reply_text(message)
+
+
+def main() -> None:
+    token = os.getenv("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("recommend", recommend))
+
+    logging.info("Bot started")
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a simple telegram bot (`bot.py`) that fetches stock history using yfinance
- add moving-average based analysis for buy/sell suggestions
- update README with setup instructions and disclaimer

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684814801e84832eabe309c597101c4b