### PR TITLE
Improve network robustness and error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Trading Bot
 
 This Telegram bot collects stock data from the Moscow Exchange when possible and falls back to Yahoo Finance. It performs basic technical analysis and can show the latest price. **Use at your own risk. This is not professional financial advice.**
 
+All network requests use a 10 second timeout, and any connection failures are reported to the user.
+
 Setup
 -----
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- add `DataFetchError` and timeout session for network requests
- enforce timeouts for all fetch functions
- surface error messages to Telegram users
- mention timeout behaviour in the README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685b9a752e4c832e9a4b27be87d65ffc